### PR TITLE
Use path.join for default build_dir

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -2,6 +2,7 @@
 var open = require("open");
 var prog = require("commander");
 var pkg = require("../package.json");
+var path = require("path");
 
 // Defaults
 process.env.NODE_ENV = "production";
@@ -9,14 +10,14 @@ process.env.NODE_ENV = "production";
 prog
 	.version(`${pkg.name} v${pkg.version}`, "-v, --version")
 	.option("-p, --port [port]", "port to serve from (e.g; 5500)")
-	.option("-b, --build_dir [build_dir]", "truffle contracts build directory (e.g; ./builds/contracts/")
+	.option("-b, --build_dir [build_dir]", "truffle contracts build directory (e.g; ./build/contracts/")
 	.option("-h, --host [host]", "rpc provider host (e.g; http://localhost:7545/)")
 	.option("-i, --networkId [networkId]", "the network id (e.g; 5777)")
 	.parse(process.argv);
 
 // Args
 process.env.PORT = prog.port || 5500;
-process.env.CONTRACT_BUILD_DIR = prog.build_dir || ".\\build\\contracts\\";
+process.env.CONTRACT_BUILD_DIR = prog.build_dir || path.join('.', 'build', 'contracts');
 process.env.NETWORK_HOST = prog.host || "http://localhost:7545";
 process.env.NETWORK_ID = prog.networkId || "5777";
 

--- a/server/src/config/App.ts
+++ b/server/src/config/App.ts
@@ -14,7 +14,7 @@ const AppConfig = {
 	ETHERSCAN_APIKEY: process.env.ETHERSCAN_APIKEY,
 	NETWORK_HOST: process.env.NETWORK_HOST || "http://localhost:7545",
 	NETWORK_ID: process.env.NETWORK_ID || "5777",
-	CONTRACT_BUILD_DIR: process.env.CONTRACT_BUILD_DIR ? process.env.CONTRACT_BUILD_DIR : "./build/contracts",
+	CONTRACT_BUILD_DIR: process.env.CONTRACT_BUILD_DIR ? process.env.CONTRACT_BUILD_DIR : path.join('.', 'build', 'contracts'),
 	UI_DIR: process.env.ui_directory ? path.join(projectRoot, process.env.ui_directory) : path.join(projectRoot, "client/build")
 };
 


### PR DESCRIPTION
**Description**
The default build directory in cli.js was set to ".\\build\\contracts\\", which is a windows notation. This caused the default command to fail on my MacBook as it couldn't find the build directory. I changed this to use path.join for a platform independent path.

**Types of changes**
- [x] Bug fix (non-breaking change, which fixes an issue)
